### PR TITLE
Implement Simple Contact plugin foundation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.github/ export-ignore
+/.vscode/ export-ignore
+/.idea/ export-ignore
+/tests/ export-ignore
+/docs/ export-ignore
+/.editorconfig export-ignore
+/phpcs.xml* export-ignore
+/phpmd.xml* export-ignore
+/phpunit.xml* export-ignore
+/CHANGELOG.md export-ignore
+/README.md export-ignore
+/CONTRIBUTING.md export-ignore
+/package.json export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# OS
+.DS_Store
+.DS_Store?
+Thumbs.db
+ehthumbs.db
+Icon?
+._*
+
+# Editors
+.vscode/
+.idea/
+*.iml
+
+# Node / frontend
+node_modules/
+npm-debug.log*
+yarn-error.log
+dist/
+build/
+
+# PHP tooling
+vendor/
+composer.lock
+
+# Logs & temp
+*.log
+*.tmp
+*.cache
+
+# Coverage
+coverage/
+.clover
+.phpunit.result.cache

--- a/Documents.md
+++ b/Documents.md
@@ -1,0 +1,82 @@
+# Simple Contact Shortcode & Block Documentation
+
+## Quick Navigation
+- [Architecture](#architecture)
+- [Data Schema](#data-schema)
+- [Public APIs](#public-apis)
+- [Actions & Filters](#actions--filters)
+- [Shortcode Usage](#shortcode-usage)
+- [Block Usage](#block-usage)
+- [Submission Workflow](#submission-workflow)
+- [Uninstall Behavior](#uninstall-behavior)
+- [Testing & QA](#testing--qa)
+
+## Architecture
+The plugin is organized into modular classes under the `includes/` directory:
+- `class-sc-plugin.php`: Boots the plugin, registers hooks, and loads translations.
+- `class-sc-installer.php`: Handles database migrations via the activation hook and provides `maybe_upgrade_schema()`.
+- `class-sc-form.php`: Renders the contact form markup shared by the shortcode and block.
+- `class-sc-form-handler.php`: Processes submissions, sanitizes input, persists records, and dispatches notification emails.
+- `class-sc-shortcode.php`: Registers the `[simple_contact]` shortcode and delegates rendering to the shared form renderer.
+- `class-sc-block.php`: Registers the Gutenberg block `simple-contact/form` with server-side rendering using the shared form renderer.
+
+Assets live under `assets/` and currently include a vanilla JavaScript block implementation in `assets/js/block.js`. Translation templates are kept in `languages/simple-contact.pot`.
+
+## Data Schema
+The plugin creates a custom table named `{prefix}sc_contacts` with the following columns:
+| Column     | Type                 | Notes |
+|------------|----------------------|-------|
+| `id`       | `BIGINT UNSIGNED`    | Primary key. |
+| `name`     | `VARCHAR(120)`       | Sanitized with `sanitize_text_field()`. |
+| `email`    | `VARCHAR(190)`       | Validated via `is_email()`. |
+| `created_at` | `DATETIME`         | Stored in UTC. |
+| `consent_ip` | `VARBINARY(16)`    | IP address stored as packed binary when available. |
+| `user_agent` | `VARCHAR(255)`     | Optional user agent string. |
+
+Indexes: `PRIMARY (id)`, `INDEX (email)`, `INDEX (created_at)`.
+
+Schema updates are managed by `Simple_Contact_Installer::maybe_upgrade_schema()` which records the schema version in the option `simple_contact_schema_version`.
+
+## Public APIs
+- Shortcode `[simple_contact]` with attributes:
+  - `success_message` (string, optional) – Overrides the default localized success message.
+  - `css_class` (string, optional) – Additional CSS classes appended to the wrapping `<div>`.
+- Block `simple-contact/form` attributes:
+  - `successMessage` (string) – Mirrors the shortcode `success_message` attribute.
+  - `cssClass` (string) – Mirrors the shortcode `css_class` attribute.
+
+## Actions & Filters
+- `sc_before_insert_contact( array $sanitized_data )`: Fired before the submission data is persisted.
+- `sc_after_insert_contact( int $contact_id, array $data )`: Fired after a new contact row is saved.
+- `sc_email_to( string $recipient, array $data )`: Filters the notification recipient email address.
+- `sc_email_subject( string $subject, array $data )`: Filters the notification subject line.
+- `sc_email_headers( array $headers, array $data )`: Filters the notification email headers.
+- `sc_success_message( string $message, array $data )`: Filters the success message shown to the user.
+
+## Shortcode Usage
+```
+[simple_contact]
+```
+Optional parameters:
+```
+[simple_contact success_message="Thank you!" css_class="is-style-card"]
+```
+
+## Block Usage
+Insert the **Simple Contact Form** block (`simple-contact/form`) from the Widgets category. Configure the success message and extra CSS classes via the block inspector.
+
+## Submission Workflow
+1. The form renders with fields for name and email plus a nonce and hidden redirect URL.
+2. On submission, WordPress routes the request through the `admin_post` endpoints.
+3. `Simple_Contact_Form_Handler` validates nonce, sanitizes input, and confirms email validity.
+4. Valid submissions are inserted into `{prefix}sc_contacts` with the visitor IP and user agent when present.
+5. Notification emails are sent to the site administrator. Filters allow customization of recipient, subject, and headers.
+6. Users are redirected back to the originating page with either a success or error query parameter to display feedback.
+
+## Uninstall Behavior
+Deleting the plugin triggers `uninstall.php`, which loads the installer class, drops the custom table via `maybe_drop_table()`, and removes the stored schema version option.
+
+## Testing & QA
+- Run `vendor/bin/phpcs --standard=WordPress --ignore=vendor .` to ensure coding standard compliance.
+- Manually verify form submission happy and error paths on the front end.
+- Confirm uninstall removes the database table and related options.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,17 @@
+# TODO
+
+## Pending
+- Implement automated email testing strategy.
+- Create end-to-end tests for form submission workflow.
+
+## In Progress
+- Prepare automated QA checklist for future releases.
+
+## Completed
+- Scaffold plugin structure for Simple Contact Shortcode & Block.
+- Implement contact form shortcode and Gutenberg block.
+- Add database schema migration and uninstall cleanup.
+- Document plugin architecture and public APIs.
+- Normalize indentation and bring all PHP files into compliance with WordPress Coding Standards.
+- Reformat Gutenberg block script to satisfy WordPress JavaScript coding standards.
+- Replace direct DROP TABLE query with `maybe_drop_table()` during uninstall for safer cleanup.

--- a/assets/js/block.js
+++ b/assets/js/block.js
@@ -1,0 +1,88 @@
+/**
+ * Gutenberg block registration script for Simple Contact.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/* global wp */
+
+( function ( blocks, element, i18n, editor, components ) {
+	var __                = i18n.__;
+	var el                = element.createElement;
+	var InspectorControls = editor.InspectorControls;
+	var useBlockProps     = editor.useBlockProps ? editor.useBlockProps : function () {
+		return {};
+	};
+	var PanelBody         = components.PanelBody;
+	var TextControl       = components.TextControl;
+
+	blocks.registerBlockType(
+		'simple-contact/form',
+		{
+			title: __( 'Simple Contact Form', 'simple-contact' ),
+			description: __( 'Display a simple contact form that stores submissions and emails the site administrator.', 'simple-contact' ),
+			icon: 'email',
+			category: 'widgets',
+			attributes: {
+				successMessage: {
+					type: 'string',
+					default: '',
+				},
+				cssClass: {
+					type: 'string',
+					default: '',
+				},
+			},
+			edit: function ( props ) {
+				var attributes    = props.attributes;
+				var setAttributes = props.setAttributes;
+				var blockProps    = useBlockProps( { className: 'simple-contact-form-block-preview' } );
+
+				return el(
+					element.Fragment,
+					null,
+					el(
+						InspectorControls,
+						null,
+						el(
+							PanelBody,
+							{ title: __( 'Form Settings', 'simple-contact' ), initialOpen: true },
+							el(
+								TextControl,
+								{
+									label: __( 'Success message', 'simple-contact' ),
+									help: __( 'Optional message displayed after a successful submission.', 'simple-contact' ),
+									value: attributes.successMessage,
+									onChange: function ( value ) {
+										setAttributes( { successMessage: value } );
+									},
+								},
+							),
+							el(
+								TextControl,
+								{
+									label: __( 'Additional CSS classes', 'simple-contact' ),
+									help: __( 'Space separated list of classes added to the form wrapper.', 'simple-contact' ),
+									value: attributes.cssClass,
+									onChange: function ( value ) {
+										setAttributes( { cssClass: value } );
+									},
+								},
+							)
+						)
+					),
+					el(
+						'div',
+						blockProps,
+						el( 'p', { className: 'simple-contact-form-block-preview__title' }, __( 'Simple Contact Form', 'simple-contact' ) ),
+						el( 'p', { className: 'simple-contact-form-block-preview__description' }, __( 'The form will be rendered on the front end.', 'simple-contact' ) )
+					)
+				);
+			},
+			save: function () {
+				return null;
+			},
+		}
+	);
+}( window.wp.blocks, window.wp.element, window.wp.i18n, window.wp.blockEditor || window.wp.editor, window.wp.components ) );

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+"name": "codex/simple-contact",
+"description": "Simple Contact Shortcode & Block plugin development tools",
+"type": "project",
+"license": "GPL-2.0-or-later",
+"require-dev": {
+"squizlabs/php_codesniffer": "^3.7",
+"wp-coding-standards/wpcs": "^3.0"
+},
+"scripts": {
+"phpcs": "phpcs --standard=WordPress --ignore=vendor"
+},
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}

--- a/includes/class-simple-contact-block.php
+++ b/includes/class-simple-contact-block.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Registers the Gutenberg block for the contact form.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/**
+ * Class Simple_Contact_Block
+ *
+ * Registers the block type and renders on the server.
+ *
+ * @since 1.0.0
+ */
+class Simple_Contact_Block {
+	/**
+	 * Block name identifier.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	const BLOCK_NAME = 'simple-contact/form';
+
+	/**
+	 * Registers block assets and block type.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		if ( ! function_exists( 'register_block_type' ) ) {
+			return;
+		}
+
+		wp_register_script(
+			'simple-contact-block',
+			SIMPLE_CONTACT_URL . 'assets/js/block.js',
+			array( 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-block-editor', 'wp-components' ),
+			SIMPLE_CONTACT_VERSION,
+			true
+		);
+
+		wp_set_script_translations( 'simple-contact-block', 'simple-contact', SIMPLE_CONTACT_PATH . 'languages' );
+
+		register_block_type(
+			self::BLOCK_NAME,
+			array(
+				'editor_script'   => 'simple-contact-block',
+				'render_callback' => array( __CLASS__, 'render_block' ),
+				'attributes'      => array(
+					'successMessage' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'cssClass'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Renders the block on the front end.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string
+	 */
+	public static function render_block( $attributes ) {
+		$atts = array(
+			'success_message' => isset( $attributes['successMessage'] ) && is_string( $attributes['successMessage'] ) ? sanitize_text_field( $attributes['successMessage'] ) : '',
+			'css_class'       => isset( $attributes['cssClass'] ) && is_string( $attributes['cssClass'] ) ? sanitize_text_field( $attributes['cssClass'] ) : '',
+		);
+
+		return Simple_Contact_Form::render( $atts, '' );
+	}
+}

--- a/includes/class-simple-contact-form-handler.php
+++ b/includes/class-simple-contact-form-handler.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Handles processing of contact form submissions.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/**
+ * Class Simple_Contact_Form_Handler
+ *
+ * Manages submission validation, persistence, and notifications.
+ *
+ * @since 1.0.0
+ */
+class Simple_Contact_Form_Handler {
+	/**
+	 * Registers WordPress actions for processing submissions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		add_action( 'admin_post_nopriv_simple_contact_submit', array( __CLASS__, 'handle' ) );
+		add_action( 'admin_post_simple_contact_submit', array( __CLASS__, 'handle' ) );
+	}
+
+	/**
+	 * Handles form submissions routed through admin-post.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function handle() {
+		$redirect_to = self::get_redirect_url();
+
+		if ( empty( $_POST['simple_contact_nonce'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			self::redirect_with_status( 'error', 'nonce', $redirect_to );
+		}
+
+		if ( ! check_admin_referer( 'simple_contact_submit', 'simple_contact_nonce' ) ) {
+			self::redirect_with_status( 'error', 'nonce', $redirect_to );
+		}
+
+		$name  = isset( $_POST['simple_contact_name'] ) ? sanitize_text_field( wp_unslash( $_POST['simple_contact_name'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$email = isset( $_POST['simple_contact_email'] ) ? sanitize_email( wp_unslash( $_POST['simple_contact_email'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		if ( '' === $name || '' === $email ) {
+			self::redirect_with_status( 'error', 'missing_fields', $redirect_to );
+		}
+
+		if ( ! is_email( $email ) ) {
+			self::redirect_with_status( 'error', 'invalid_email', $redirect_to );
+		}
+
+		$data = array(
+			'name'       => $name,
+			'email'      => $email,
+			'created_at' => gmdate( 'Y-m-d H:i:s' ),
+			'consent_ip' => self::get_packed_ip(),
+			'user_agent' => self::get_user_agent(),
+		);
+
+		/**
+		 * Fires before a contact entry is inserted.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $data Sanitized submission data.
+		 */
+		do_action( 'sc_before_insert_contact', $data );
+
+		$insert_id = self::insert_submission( $data );
+
+		if ( false === $insert_id ) {
+			self::redirect_with_status( 'error', 'database', $redirect_to );
+		}
+
+		self::send_notification( $data, $insert_id );
+
+		/**
+		 * Fires after a contact entry is inserted.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int   $insert_id Row ID of the new contact.
+		 * @param array $data      Submission data saved to the database.
+		 */
+		do_action( 'sc_after_insert_contact', $insert_id, $data );
+
+		self::redirect_with_status( 'success', '', $redirect_to );
+	}
+
+	/**
+	 * Determines redirect URL from submission payload.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	private static function get_redirect_url() {
+		if ( empty( $_POST['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return home_url();
+		}
+
+		$redirect = esc_url_raw( wp_unslash( $_POST['redirect_to'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		return wp_validate_redirect( $redirect, home_url() );
+	}
+
+	/**
+	 * Inserts submission data into the database.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $data Sanitized data ready for insertion.
+	 *
+	 * @return int|false Inserted row ID on success, false otherwise.
+	 */
+	private static function insert_submission( array $data ) {
+		global $wpdb;
+
+		$table    = $wpdb->prefix . 'sc_contacts';
+		$formats  = array( '%s', '%s', '%s', '%s', '%s' );
+		$inserted = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table,
+			array(
+				'name'       => $data['name'],
+				'email'      => $data['email'],
+				'created_at' => $data['created_at'],
+				'consent_ip' => $data['consent_ip'],
+				'user_agent' => $data['user_agent'],
+			),
+			$formats
+		);
+
+		if ( false === $inserted ) {
+			return false;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Sends the admin notification email.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $data      Submission data.
+	 * @param int   $insert_id Inserted row ID.
+	 *
+	 * @return void
+	 */
+	private static function send_notification( array $data, $insert_id ) {
+		$to      = apply_filters( 'sc_email_to', get_option( 'admin_email' ), $data );
+		$subject = apply_filters( 'sc_email_subject', __( 'New contact form submission', 'simple-contact' ), $data );
+		$headers = apply_filters( 'sc_email_headers', array( 'Content-Type: text/plain; charset=UTF-8' ), $data );
+
+		$message_body = sprintf(
+			"%s\n\n%s: %s\n%s: %s\n%s: %d",
+			__( 'You have received a new contact form submission.', 'simple-contact' ),
+			__( 'Name', 'simple-contact' ),
+			$data['name'],
+			__( 'Email', 'simple-contact' ),
+			$data['email'],
+			__( 'Entry ID', 'simple-contact' ),
+			$insert_id
+		);
+
+		wp_mail( $to, $subject, $message_body, $headers );
+	}
+
+	/**
+	 * Retrieves the visitor IP address as packed binary.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string|null Packed binary address or null if unavailable.
+	 */
+	private static function get_packed_ip() {
+		$ip = filter_input( INPUT_SERVER, 'REMOTE_ADDR', FILTER_VALIDATE_IP );
+
+		if ( empty( $ip ) ) {
+			return null;
+		}
+
+		$packed = inet_pton( $ip );
+
+		return false === $packed ? null : $packed;
+	}
+
+	/**
+	 * Retrieves the visitor user agent string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string|null Sanitized user agent or null when absent.
+	 */
+	private static function get_user_agent() {
+		$agent = filter_input( INPUT_SERVER, 'HTTP_USER_AGENT', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+		if ( empty( $agent ) ) {
+			return null;
+		}
+
+		$sanitized = sanitize_text_field( $agent );
+
+		return '' === $sanitized ? null : $sanitized;
+	}
+
+	/**
+	 * Redirects the user with query arguments for status messages.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $status       Either 'success' or 'error'.
+	 * @param string $code         Optional error code.
+	 * @param string $redirect_url Redirect destination.
+	 *
+	 * @return void
+	 */
+	private static function redirect_with_status( $status, $code = '', $redirect_url = '' ) {
+		$redirect_url = '' === $redirect_url ? home_url() : $redirect_url;
+
+		$args = array( 'sc_status' => $status );
+
+		if ( '' !== $code ) {
+			$args['sc_error'] = $code;
+		} else {
+			$args['sc_error'] = false;
+		}
+
+		$location = add_query_arg( $args, $redirect_url );
+
+		wp_safe_redirect( $location );
+		exit;
+	}
+}

--- a/includes/class-simple-contact-form.php
+++ b/includes/class-simple-contact-form.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Provides shared rendering utilities for the contact form.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/**
+ * Class Simple_Contact_Form
+ *
+ * Renders the form used by both the shortcode and block.
+ *
+ * @since 1.0.0
+ */
+class Simple_Contact_Form {
+	/**
+	 * Renders the contact form markup.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $attributes Shortcode or block attributes.
+	 * @param string $content    Optional content (unused).
+	 *
+	 * @return string
+	 */
+	public static function render( $attributes = array(), $content = '' ) {
+		unset( $content );
+
+		$defaults   = array(
+			'success_message' => __( 'Thank you for contacting us. We will get back to you soon.', 'simple-contact' ),
+			'css_class'       => '',
+		);
+		$attributes = wp_parse_args( $attributes, $defaults );
+
+		$success_message = is_string( $attributes['success_message'] ) ? sanitize_text_field( $attributes['success_message'] ) : sanitize_text_field( $defaults['success_message'] );
+		$css_class       = is_string( $attributes['css_class'] ) ? sanitize_text_field( $attributes['css_class'] ) : '';
+
+		$status      = self::get_query_param( 'sc_status' );
+		$error_code  = self::get_query_param( 'sc_error' );
+		$notice_html = self::prepare_notice( $status, $error_code, $success_message );
+
+		$classes = array( 'simple-contact-form' );
+		if ( '' !== $css_class ) {
+			$classes = array_merge( $classes, self::sanitize_class_list( $css_class ) );
+		}
+
+		$action      = admin_url( 'admin-post.php' );
+		$redirect_to = self::get_current_url();
+
+		ob_start();
+		?>
+<div class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+		<?php if ( ! empty( $notice_html ) ) : ?>
+<div class="simple-contact-notice"><?php echo wp_kses_post( $notice_html ); ?></div>
+<?php endif; ?>
+<form method="post" action="<?php echo esc_url( $action ); ?>" class="simple-contact-form__fields">
+<p class="simple-contact-field">
+<label for="simple-contact-name"><?php echo esc_html__( 'Name', 'simple-contact' ); ?></label>
+<input type="text" id="simple-contact-name" name="simple_contact_name" required />
+</p>
+<p class="simple-contact-field">
+<label for="simple-contact-email"><?php echo esc_html__( 'Email', 'simple-contact' ); ?></label>
+<input type="email" id="simple-contact-email" name="simple_contact_email" required />
+</p>
+<input type="hidden" name="action" value="simple_contact_submit" />
+<input type="hidden" name="redirect_to" value="<?php echo esc_attr( $redirect_to ); ?>" />
+		<?php wp_nonce_field( 'simple_contact_submit', 'simple_contact_nonce' ); ?>
+<p class="simple-contact-actions">
+<button type="submit" class="simple-contact-submit"><?php echo esc_html__( 'Send', 'simple-contact' ); ?></button>
+</p>
+</form>
+</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Builds the feedback notice HTML.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $status          Submission status parameter.
+	 * @param string $error_code      Error code parameter.
+	 * @param string $success_message Success message attribute.
+	 *
+	 * @return string
+	 */
+	private static function prepare_notice( $status, $error_code, $success_message ) {
+		if ( 'success' === $status ) {
+			$message = apply_filters( 'sc_success_message', $success_message, array() );
+			return esc_html( $message );
+		}
+
+		if ( '' === $error_code ) {
+			return '';
+		}
+
+		switch ( $error_code ) {
+			case 'invalid_email':
+				$message = __( 'Please provide a valid email address.', 'simple-contact' );
+				break;
+			case 'missing_fields':
+				$message = __( 'Please fill in both your name and email.', 'simple-contact' );
+				break;
+			case 'nonce':
+				$message = __( 'Security check failed. Please try again.', 'simple-contact' );
+				break;
+			case 'database':
+				$message = __( 'We could not process your request. Please try again.', 'simple-contact' );
+				break;
+			default:
+				$message = __( 'We could not process your request. Please try again.', 'simple-contact' );
+		}
+
+		return esc_html( $message );
+	}
+
+	/**
+	 * Sanitizes a list of CSS classes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $class_list Raw class list string.
+	 *
+	 * @return array
+	 */
+	private static function sanitize_class_list( $class_list ) {
+		$sanitized = array();
+
+		foreach ( preg_split( '/\s+/', $class_list ) as $class_name ) {
+			$class_name = trim( $class_name );
+
+			if ( '' === $class_name ) {
+				continue;
+			}
+
+			$sanitized_class = sanitize_html_class( $class_name );
+
+			if ( '' !== $sanitized_class ) {
+				$sanitized[] = $sanitized_class;
+			}
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Determines the current URL for redirecting after submission.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	private static function get_current_url() {
+		$host = filter_input( INPUT_SERVER, 'HTTP_HOST', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$uri  = filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+		if ( empty( $host ) || empty( $uri ) ) {
+			return home_url();
+		}
+
+		$scheme = is_ssl() ? 'https' : 'http';
+
+		return esc_url_raw( sprintf( '%s://%s%s', $scheme, $host, $uri ) );
+	}
+
+	/**
+	 * Retrieves a sanitized query parameter.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key Query key to fetch.
+	 *
+	 * @return string
+	 */
+	private static function get_query_param( $key ) {
+		$value = filter_input( INPUT_GET, $key, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+		return is_string( $value ) ? sanitize_text_field( $value ) : '';
+	}
+}

--- a/includes/class-simple-contact-installer.php
+++ b/includes/class-simple-contact-installer.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Handles plugin installation tasks such as database schema creation.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/**
+ * Class Simple_Contact_Installer
+ *
+ * Creates and upgrades the custom contact table.
+ *
+ * @since 1.0.0
+ */
+class Simple_Contact_Installer {
+	/**
+	 * Schema version option key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	const OPTION_KEY = 'simple_contact_schema_version';
+
+	/**
+	 * Current database schema version.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	const VERSION = '1.0.0';
+
+	/**
+	 * Runs on plugin activation to install or upgrade schema.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function activate() {
+		self::maybe_upgrade_schema();
+	}
+
+	/**
+	 * Installs or upgrades the database schema when required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @return void
+	 */
+	public static function maybe_upgrade_schema() {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . 'sc_contacts';
+		$charset_collate = $wpdb->get_charset_collate();
+		$sql             = "CREATE TABLE {$table_name} (\n" .
+			"\tid BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,\n" .
+			"\tname VARCHAR(120) NOT NULL,\n" .
+			"\temail VARCHAR(190) NOT NULL,\n" .
+			"\tcreated_at DATETIME NOT NULL,\n" .
+			"\tconsent_ip VARBINARY(16) NULL,\n" .
+			"\tuser_agent VARCHAR(255) NULL,\n" .
+			"\tPRIMARY KEY  (id),\n" .
+			"\tKEY email (email),\n" .
+			"\tKEY created_at (created_at)\n" .
+			") {$charset_collate};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		// phpcs:ignore WordPress.DB.DirectDatabaseSchema,WordPress.DB.DirectDatabaseSchema.SchemaChange -- Schema creation handled via dbDelta is expected during installation.
+		dbDelta( $sql );
+
+		update_option( self::OPTION_KEY, self::VERSION );
+	}
+
+	/**
+	 * Cleans up data during uninstall.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @return void
+	 */
+	public static function uninstall() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'sc_contacts';
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		maybe_drop_table( $table_name, "DROP TABLE IF EXISTS {$table_name}" );
+
+		delete_option( self::OPTION_KEY );
+	}
+}

--- a/includes/class-simple-contact-plugin.php
+++ b/includes/class-simple-contact-plugin.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Main plugin bootstrap file.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/**
+ * Class Simple_Contact_Plugin
+ *
+ * Boots the plugin and registers core hooks.
+ *
+ * @since 1.0.0
+ */
+class Simple_Contact_Plugin {
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Simple_Contact_Plugin
+	 */
+	private static $instance;
+
+	/**
+	 * Retrieves the singleton instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Simple_Contact_Plugin
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * Registers hooks required for the plugin to operate.
+	 *
+	 * @since 1.0.0
+	 */
+	private function __construct() {
+		$this->load_dependencies();
+		$this->register_hooks();
+	}
+
+	/**
+	 * Loads the PHP dependencies.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function load_dependencies() {
+		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-installer.php';
+		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-form.php';
+		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-form-handler.php';
+		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-shortcode.php';
+		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-block.php';
+	}
+
+	/**
+	 * Registers WordPress hooks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function register_hooks() {
+		register_activation_hook( SIMPLE_CONTACT_PLUGIN_FILE, array( 'Simple_Contact_Installer', 'activate' ) );
+		register_uninstall_hook( SIMPLE_CONTACT_PLUGIN_FILE, array( 'Simple_Contact_Installer', 'uninstall' ) );
+
+		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+		add_action( 'init', array( 'Simple_Contact_Shortcode', 'register' ) );
+		add_action( 'init', array( 'Simple_Contact_Block', 'register' ) );
+
+		Simple_Contact_Form_Handler::register();
+	}
+
+	/**
+	 * Loads the plugin text domain for translations.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function load_textdomain() {
+		load_plugin_textdomain( 'simple-contact', false, dirname( plugin_basename( SIMPLE_CONTACT_PLUGIN_FILE ) ) . '/languages' );
+	}
+}

--- a/includes/class-simple-contact-shortcode.php
+++ b/includes/class-simple-contact-shortcode.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Registers the contact form shortcode.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/**
+ * Class Simple_Contact_Shortcode
+ *
+ * Registers and renders the [simple_contact] shortcode.
+ *
+ * @since 1.0.0
+ */
+class Simple_Contact_Shortcode {
+	/**
+	 * Registers the shortcode with WordPress.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		add_shortcode( 'simple_contact', array( __CLASS__, 'render' ) );
+	}
+
+	/**
+	 * Renders the shortcode output.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $atts    Shortcode attributes.
+	 * @param string $content Enclosed content (unused).
+	 *
+	 * @return string
+	 */
+	public static function render( $atts, $content = '' ) {
+		$atts = shortcode_atts(
+			array(
+				'success_message' => '',
+				'css_class'       => '',
+			),
+			$atts,
+			'simple_contact'
+		);
+
+		$atts['success_message'] = is_string( $atts['success_message'] ) ? sanitize_text_field( $atts['success_message'] ) : '';
+		$atts['css_class']       = is_string( $atts['css_class'] ) ? sanitize_text_field( $atts['css_class'] ) : '';
+
+		return Simple_Contact_Form::render( $atts, $content );
+	}
+}

--- a/languages/simple-contact.pot
+++ b/languages/simple-contact.pot
@@ -1,0 +1,84 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Simple Contact Shortcode & Block 1.0.0\n"
+"POT-Creation-Date: 2024-01-01 00:00:00+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Codex Agent\n"
+
+#: includes/class-sc-form.php
+msgid "Thank you for contacting us. We will get back to you soon."
+msgstr ""
+
+#: includes/class-sc-form.php
+msgid "Name"
+msgstr ""
+
+#: includes/class-sc-form.php
+msgid "Email"
+msgstr ""
+
+#: includes/class-sc-form.php
+msgid "Send"
+msgstr ""
+
+#: includes/class-sc-form.php
+msgid "Please provide a valid email address."
+msgstr ""
+
+#: includes/class-sc-form.php
+msgid "Please fill in both your name and email."
+msgstr ""
+
+#: includes/class-sc-form.php
+msgid "Security check failed. Please try again."
+msgstr ""
+
+#: includes/class-sc-form.php
+msgid "We could not process your request. Please try again."
+msgstr ""
+
+#: includes/class-sc-form-handler.php
+msgid "New contact form submission"
+msgstr ""
+
+#: includes/class-sc-form-handler.php
+msgid "You have received a new contact form submission."
+msgstr ""
+
+#: includes/class-sc-form-handler.php
+msgid "Entry ID"
+msgstr ""
+
+#: assets/js/block.js
+msgid "Simple Contact Form"
+msgstr ""
+
+#: assets/js/block.js
+msgid "Display a simple contact form that stores submissions and emails the site administrator."
+msgstr ""
+
+#: assets/js/block.js
+msgid "Form Settings"
+msgstr ""
+
+#: assets/js/block.js
+msgid "Success message"
+msgstr ""
+
+#: assets/js/block.js
+msgid "Optional message displayed after a successful submission."
+msgstr ""
+
+#: assets/js/block.js
+msgid "Additional CSS classes"
+msgstr ""
+
+#: assets/js/block.js
+msgid "Space separated list of classes added to the form wrapper."
+msgstr ""
+
+#: assets/js/block.js
+msgid "The form will be rendered on the front end."
+msgstr ""

--- a/simple-contact.php
+++ b/simple-contact.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: Simple Contact Shortcode & Block
+ * Plugin URI: https://example.com/simple-contact
+ * Description: Provides a simple contact form via shortcode and Gutenberg block, stores submissions, and notifies the admin.
+ * Version: 1.0.0
+ * Author: Codex
+ * Author URI: https://example.com
+ * Text Domain: simple-contact
+ * Domain Path: /languages
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ *
+ * @package SimpleContact
+ */
+
+define( 'SIMPLE_CONTACT_VERSION', '1.0.0' );
+define( 'SIMPLE_CONTACT_PLUGIN_FILE', __FILE__ );
+define( 'SIMPLE_CONTACT_PATH', plugin_dir_path( SIMPLE_CONTACT_PLUGIN_FILE ) );
+define( 'SIMPLE_CONTACT_URL', plugin_dir_url( SIMPLE_CONTACT_PLUGIN_FILE ) );
+
+require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-plugin.php';
+
+// Bootstrap the plugin.
+Simple_Contact_Plugin::get_instance();

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Handles plugin data cleanup on uninstall.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+require_once __DIR__ . '/includes/class-simple-contact-installer.php';
+
+Simple_Contact_Installer::uninstall();


### PR DESCRIPTION
## Summary
- add the Simple Contact plugin bootstrap, installer, and form/handler classes following WordPress coding standards
- provide shortcode, block, and editor script assets plus uninstall cleanup
- document architecture and tasks while keeping repository packaging metadata up to date

## Testing
- vendor/bin/phpcs --standard=WordPress --ignore=vendor .

------
https://chatgpt.com/codex/tasks/task_e_68cc246a14f883298981de6e69eaea9c