### PR TITLE
Add notification service and unit test coverage

### DIFF
--- a/Documents.md
+++ b/Documents.md
@@ -17,6 +17,7 @@ The plugin is organized into modular classes under the `includes/` directory:
 - `class-simple-contact-installer.php`: Handles database migrations via the activation hook and provides `maybe_upgrade_schema()`.
 - `class-simple-contact-form.php`: Renders the contact form markup shared by the shortcode and block.
 - `class-simple-contact-form-handler.php`: Processes submissions, sanitizes input, persists records, and dispatches notification emails.
+- `class-simple-contact-notification.php`: Composes the notification message and triggers `wp_mail()` with filtered headers, recipient, and subject.
 - `class-simple-contact-shortcode.php`: Registers the `[simple_contact]` shortcode and delegates rendering to the shared form renderer.
 - `class-simple-contact-block.php`: Registers the Gutenberg block `simple-contact/form` with server-side rendering using the shared form renderer.
 
@@ -85,6 +86,7 @@ Source control hygiene ensures release archives remain focused on runtime necess
 ### Automated checks
 - Install dependencies with `composer install`.
 - Run coding standards via `composer phpcs`.
+- Execute unit tests with `composer test` to validate the notification delivery workflow using Brain Monkey.
 
 ### Manual checklist
 1. Activate the plugin and confirm the `{prefix}sc_contacts` table is created (verify via database inspection or tools like `wp db tables`).

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,14 @@
 # TODO
 
 ## Pending
-- Implement automated email testing strategy.
 - Create end-to-end tests for form submission workflow.
+- Add PHPUnit coverage for form handler redirect and error handling.
 
 ## In Progress
 - _None_.
 
 ## Completed
+- Implement automated email testing strategy.
 - Establish repository hygiene via project-level `.gitignore` and `.gitattributes` files to enforce clean distributions.
 - Implement transient-backed success payload so `sc_success_message` receives sanitized submission data.
 - Normalize success payload data to expose human-readable IP addresses to filters.

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,20 @@
     "license": "GPL-2.0-or-later",
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",
-        "wp-coding-standards/wpcs": "^3.0"
+        "wp-coding-standards/wpcs": "^3.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpunit/phpunit": "^9.6",
+        "brain/monkey": "^2.6",
+        "yoast/phpunit-polyfills": "^2.0"
     },
     "scripts": {
-        "phpcs": "phpcs --standard=WordPress --ignore=vendor ."
+        "phpcs": "phpcs --standard=WordPress --ignore=vendor,tests .",
+        "test": "phpunit"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SimpleContact\\Tests\\": "tests/phpunit/"
+        }
     },
     "config": {
         "allow-plugins": {

--- a/includes/class-simple-contact-form-handler.php
+++ b/includes/class-simple-contact-form-handler.php
@@ -78,7 +78,7 @@ class Simple_Contact_Form_Handler {
 			self::redirect_with_status( 'error', 'database', $redirect_to );
 		}
 
-		self::send_notification( $data, $insert_id );
+		self::dispatch_notification( $data, $insert_id );
 
 		/**
 		 * Fires after a contact entry is inserted.
@@ -151,7 +151,7 @@ class Simple_Contact_Form_Handler {
 	}
 
 	/**
-	 * Sends the admin notification email.
+	 * Dispatches the notification email via the notification service.
 	 *
 	 * @since 1.0.0
 	 *
@@ -160,23 +160,9 @@ class Simple_Contact_Form_Handler {
 	 *
 	 * @return void
 	 */
-	private static function send_notification( array $data, $insert_id ) {
-		$to      = apply_filters( 'sc_email_to', get_option( 'admin_email' ), $data );
-		$subject = apply_filters( 'sc_email_subject', __( 'New contact form submission', 'simple-contact' ), $data );
-		$headers = apply_filters( 'sc_email_headers', array( 'Content-Type: text/plain; charset=UTF-8' ), $data );
-
-		$message_body = sprintf(
-			"%s\n\n%s: %s\n%s: %s\n%s: %d",
-			__( 'You have received a new contact form submission.', 'simple-contact' ),
-			__( 'Name', 'simple-contact' ),
-			$data['name'],
-			__( 'Email', 'simple-contact' ),
-			$data['email'],
-			__( 'Entry ID', 'simple-contact' ),
-			$insert_id
-		);
-
-		wp_mail( $to, $subject, $message_body, $headers );
+	private static function dispatch_notification( array $data, $insert_id ) {
+		$notification = new Simple_Contact_Notification();
+		$notification->send( $data, $insert_id );
 	}
 
 	/**

--- a/includes/class-simple-contact-notification.php
+++ b/includes/class-simple-contact-notification.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Handles notification email dispatch for contact submissions.
+ *
+ * @package SimpleContact
+ * @since 1.0.0
+ */
+
+/**
+ * Class Simple_Contact_Notification
+ *
+ * Composes and sends notification emails for contact submissions.
+ *
+ * @since 1.0.0
+ */
+class Simple_Contact_Notification {
+	/**
+	 * Sends the notification email to the configured recipient.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $data      Sanitized submission data.
+	 * @param int   $insert_id Inserted row ID.
+	 *
+	 * @return bool True when the email dispatch reports success, false otherwise.
+	 */
+	public function send( array $data, $insert_id ) {
+		$recipient = apply_filters( 'sc_email_to', get_option( 'admin_email' ), $data );
+		$subject   = apply_filters( 'sc_email_subject', __( 'New contact form submission', 'simple-contact' ), $data );
+		$headers   = apply_filters( 'sc_email_headers', array( 'Content-Type: text/plain; charset=UTF-8' ), $data );
+
+		$message = $this->build_message( $data, $insert_id );
+
+		return (bool) wp_mail( $recipient, $subject, $message, $headers );
+	}
+
+	/**
+	 * Builds the email body content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $data      Submission data to include in the message.
+	 * @param int   $insert_id Inserted row ID.
+	 *
+	 * @return string
+	 */
+	private function build_message( array $data, $insert_id ) {
+		$name  = isset( $data['name'] ) ? sanitize_text_field( (string) $data['name'] ) : '';
+		$email = isset( $data['email'] ) ? sanitize_email( (string) $data['email'] ) : '';
+
+		return sprintf(
+			"%s\n\n%s: %s\n%s: %s\n%s: %d",
+			__( 'You have received a new contact form submission.', 'simple-contact' ),
+			__( 'Name', 'simple-contact' ),
+			$name,
+			__( 'Email', 'simple-contact' ),
+			$email,
+			__( 'Entry ID', 'simple-contact' ),
+			(int) $insert_id
+		);
+	}
+}

--- a/includes/class-simple-contact-plugin.php
+++ b/includes/class-simple-contact-plugin.php
@@ -58,6 +58,7 @@ class Simple_Contact_Plugin {
 	private function load_dependencies() {
 		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-installer.php';
 		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-form.php';
+		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-notification.php';
 		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-form-handler.php';
 		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-shortcode.php';
 		require_once SIMPLE_CONTACT_PATH . 'includes/class-simple-contact-block.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/phpunit/bootstrap.php"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="Simple Contact Plugin Tests">
+            <directory>tests/phpunit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/phpunit/NotificationTest.php
+++ b/tests/phpunit/NotificationTest.php
@@ -1,0 +1,97 @@
+<?php
+// phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase,WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for the Simple_Contact_Notification class.
+ *
+ * @package SimpleContact\Tests
+ * @since 1.0.0
+ */
+
+namespace SimpleContact\Tests;
+
+use Simple_Contact_Notification;
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Class NotificationTest
+ *
+ * @since 1.0.0
+ */
+class NotificationTest extends TestCase {
+	/**
+	 * Ensures notification emails respect filters and call wp_mail with expected data.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function test_notification_uses_filters_and_sends_email(): void {
+		$data = array(
+			'name'       => 'Jane Doe',
+			'email'      => 'jane@example.com',
+			'created_at' => '2025-01-01 12:00:00',
+		);
+
+		when( '__' )->alias(
+			static function ( $text ) {
+				return $text;
+			}
+		);
+
+		when( 'sanitize_text_field' )->alias(
+			static function ( $value ) {
+				return is_string( $value ) ? trim( $value ) : '';
+			}
+		);
+
+		when( 'sanitize_email' )->alias(
+			static function ( $value ) {
+				return is_string( $value ) ? trim( $value ) : '';
+			}
+		);
+
+		when( 'get_option' )->alias(
+			static function ( $option ) {
+				return 'admin_email' === $option ? 'admin@example.com' : null;
+			}
+		);
+
+		expectApplied( 'sc_email_to' )
+			->once()
+			->with( 'admin@example.com', $data )
+			->andReturn( 'filtered@example.com' );
+
+		expectApplied( 'sc_email_subject' )
+			->once()
+			->with( 'New contact form submission', $data )
+			->andReturn( 'Custom Subject' );
+
+		expectApplied( 'sc_email_headers' )
+			->once()
+			->with( array( 'Content-Type: text/plain; charset=UTF-8' ), $data )
+			->andReturn( array( 'Content-Type: text/plain; charset=UTF-8', 'Reply-To: jane@example.com' ) );
+
+		expect( 'wp_mail' )
+			->once()
+			->withArgs(
+				static function ( $to, $subject, $message, $headers ) {
+					return 'filtered@example.com' === $to
+						&& 'Custom Subject' === $subject
+						&& str_contains( $message, 'Name: Jane Doe' )
+						&& str_contains( $message, 'Email: jane@example.com' )
+						&& str_contains( $message, 'Entry ID: 42' )
+						&& in_array( 'Reply-To: jane@example.com', $headers, true );
+				}
+			)
+			->andReturn( true );
+
+		$notification = new Simple_Contact_Notification();
+
+		$result = $notification->send( $data, 42 );
+
+		$this->assertTrue( $result, 'Notification should report successful email dispatch.' );
+	}
+}
+// phpcs:enable WordPress.Files.FileName.NotHyphenatedLowercase,WordPress.Files.FileName.InvalidClassFileName

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Base test case for Simple Contact plugin.
+ *
+ * @package SimpleContact\Tests
+ * @since 1.0.0
+ */
+
+namespace SimpleContact\Tests;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+/**
+ * Class TestCase
+ *
+ * Provides Brain Monkey bootstrapping for plugin tests.
+ *
+ * @since 1.0.0
+ */
+abstract class TestCase extends PHPUnitTestCase {
+        /**
+         * Sets up the test case.
+         *
+         * @since 1.0.0
+         *
+         * @return void
+         */
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+        }
+
+        /**
+         * Tears down the test case.
+         *
+         * @since 1.0.0
+         *
+         * @return void
+         */
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * PHPUnit bootstrap file for Simple Contact plugin tests.
+ *
+ * @package SimpleContact\Tests
+ * @since 1.0.0
+ */
+
+require_once dirname( __DIR__, 2 ) . '/vendor/autoload.php';
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-simple-contact-notification.php';


### PR DESCRIPTION
## Summary
- extract the email dispatch into `Simple_Contact_Notification` and call it from the form handler
- wire up PHPUnit/Brain Monkey tooling with bootstrap utilities and a notification unit test
- document the new service, note the testing workflow, and refresh TODO items

## Testing
- composer test
- composer phpcs

------
https://chatgpt.com/codex/tasks/task_e_68cc3b1da510832987da7a24b8357170